### PR TITLE
feat: create Next.js hero depth experience

### DIFF
--- a/.github/workflows/generate-depth.yml
+++ b/.github/workflows/generate-depth.yml
@@ -1,0 +1,42 @@
+name: Generate depth map
+
+on:
+  push:
+    paths:
+      - "public/hero/montanas.jpg"
+  workflow_dispatch:
+
+jobs:
+  depth:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install timm opencv-python-headless Pillow
+
+      - name: Generate depth map
+        run: python scripts/generate_depth.py
+
+      - name: Commit depth map
+        run: |
+          if git status --porcelain public/hero/montanas-depth.png | grep -q .; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add public/hero/montanas-depth.png
+            git commit -m "chore: update depth map"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "../styles/globals.css";
+
+export const metadata: Metadata = {
+  title: "Montañas en profundidad",
+  description: "Hero interactivo con efecto 3D y transición a negro"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="es">
+      <head>
+        <link rel="preload" as="image" href="/hero/montanas.jpg" />
+      </head>
+      <body>
+        <div className="global-background" aria-hidden="true" />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,38 @@
+import HeroDepth from "../components/HeroDepth";
+
+export default function HomePage() {
+  return (
+    <main>
+      <HeroDepth
+        imageSrc="/hero/montanas.jpg"
+        depthSrc="/hero/montanas-depth.png"
+        fadeStart={0.7}
+        strength={0.06}
+      />
+      <section>
+        <h1>Explora la cordillera</h1>
+        <p>
+          Observa la profundidad del valle mientras el paisaje responde a tus
+          movimientos. Desplázate lentamente para disfrutar del fundido a negro
+          que integra la imagen con el resto del sitio.
+        </p>
+      </section>
+      <section>
+        <h2>Experiencia inmersiva</h2>
+        <p>
+          En dispositivos compatibles, puedes inclinar el teléfono para sentir el
+          relieve del terreno. Si prefieres menos animación, el sitio respeta tu
+          configuración y mantiene una imagen estática.
+        </p>
+      </section>
+      <section>
+        <h2>Un lienzo para historias</h2>
+        <p>
+          Añade más contenido a continuación y verás cómo el negro absoluto sirve
+          como escenario perfecto, permitiendo que las palabras cobren vida sobre
+          el paisaje.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/components/HeroDepth.tsx
+++ b/components/HeroDepth.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+
+type HeroDepthProps = {
+  imageSrc: string;
+  depthSrc: string;
+  fadeStart?: number;
+  strength?: number;
+  className?: string;
+};
+
+type UniformBundle = {
+  u_tex: { value: THREE.Texture | null };
+  u_depth: { value: THREE.Texture | null };
+  u_mouse: { value: THREE.Vector2 };
+  u_strength: { value: number };
+  u_res: { value: THREE.Vector2 };
+};
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position, 1.0);
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  precision highp float;
+  uniform sampler2D u_tex;
+  uniform sampler2D u_depth;
+  uniform vec2 u_mouse;
+  uniform float u_strength;
+  uniform vec2 u_res;
+
+  void main() {
+    vec2 uv = gl_FragCoord.xy / u_res;
+    float d = texture2D(u_depth, uv).r;
+    vec2 parallax = u_mouse * (d - 0.5) * u_strength;
+    vec4 color = texture2D(u_tex, uv + parallax);
+    gl_FragColor = color;
+  }
+`;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export default function HeroDepth({
+  imageSrc,
+  depthSrc,
+  fadeStart = 0.7,
+  strength = 0.06,
+  className
+}: HeroDepthProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const fallbackImageRef = useRef<HTMLImageElement | null>(null);
+  const uniformsRef = useRef<UniformBundle | null>(null);
+  const renderRef = useRef<(() => void) | null>(null);
+  const [hasDepth, setHasDepth] = useState<boolean | null>(null);
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  const fadeValue = clamp(fadeStart, 0.65, 0.85);
+
+  useEffect(() => {
+    let active = true;
+    const depthImage = new Image();
+    depthImage.src = depthSrc;
+    depthImage.onload = () => {
+      if (active) {
+        setHasDepth(true);
+      }
+    };
+    depthImage.onerror = () => {
+      if (active) {
+        setHasDepth(false);
+      }
+    };
+    return () => {
+      active = false;
+    };
+  }, [depthSrc]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = () => setPrefersReduced(mediaQuery.matches);
+    updatePreference();
+    mediaQuery.addEventListener("change", updatePreference);
+    return () => {
+      mediaQuery.removeEventListener("change", updatePreference);
+    };
+  }, []);
+
+  const shouldUseWebGL = !prefersReduced && hasDepth === true;
+
+  useEffect(() => {
+    if (!shouldUseWebGL) {
+      uniformsRef.current = null;
+      renderRef.current = null;
+      return;
+    }
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) {
+      return;
+    }
+
+    let renderer: THREE.WebGLRenderer | null = null;
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    const loader = new THREE.TextureLoader();
+    const mouseVector = new THREE.Vector2();
+    const uniforms: UniformBundle = {
+      u_tex: { value: null },
+      u_depth: { value: null },
+      u_mouse: { value: mouseVector },
+      u_strength: { value: strength },
+      u_res: { value: new THREE.Vector2(1, 1) }
+    };
+    uniformsRef.current = uniforms;
+
+    let frameId: number | null = null;
+    const scheduleRender = () => {
+      if (frameId !== null) return;
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        if (renderer) {
+          renderer.render(scene, camera);
+        }
+      });
+    };
+    renderRef.current = scheduleRender;
+
+    renderer = new THREE.WebGLRenderer({
+      canvas,
+      antialias: true,
+      alpha: true
+    });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+    let disposed = false;
+    let mesh: THREE.Mesh | null = null;
+    let material: THREE.ShaderMaterial | null = null;
+
+    const resize = () => {
+      if (!renderer || !container) return;
+      const { width, height } = container.getBoundingClientRect();
+      renderer.setSize(width, height, false);
+      uniforms.u_res.value.set(width, height);
+      scheduleRender();
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const x = (event.clientX - rect.left) / rect.width;
+      const y = (event.clientY - rect.top) / rect.height;
+      mouseVector.set(x * 2 - 1, -(y * 2 - 1));
+      scheduleRender();
+    };
+
+    const handlePointerLeave = () => {
+      mouseVector.set(0, 0);
+      scheduleRender();
+    };
+
+    const orientationHandler = (event: DeviceOrientationEvent) => {
+      const beta = event.beta ?? 0;
+      const gamma = event.gamma ?? 0;
+      const x = THREE.MathUtils.clamp(gamma / 45, -1, 1);
+      const y = THREE.MathUtils.clamp(beta / 45, -1, 1);
+      mouseVector.set(x, -y);
+      scheduleRender();
+    };
+
+    let orientationActive = false;
+    const enableOrientation = () => {
+      if (orientationActive) return;
+      window.addEventListener("deviceorientation", orientationHandler, true);
+      orientationActive = true;
+    };
+
+    let gestureHandler: (() => void) | null = null;
+    if (typeof DeviceOrientationEvent !== "undefined") {
+      const anyOrientationEvent = DeviceOrientationEvent as unknown as {
+        requestPermission?: () => Promise<string>;
+      };
+      if (typeof anyOrientationEvent.requestPermission === "function") {
+        gestureHandler = () => {
+          anyOrientationEvent
+            .requestPermission!()
+            .then((state) => {
+              if (state === "granted") {
+                enableOrientation();
+              }
+            })
+            .catch(() => {
+              /* ignored */
+            });
+        };
+        container.addEventListener("click", gestureHandler, { once: true });
+        container.addEventListener("touchstart", gestureHandler, {
+          once: true
+        });
+      } else {
+        enableOrientation();
+      }
+    }
+
+    const onResize = () => resize();
+
+    container.addEventListener("pointermove", handlePointerMove);
+    container.addEventListener("pointerleave", handlePointerLeave);
+    container.addEventListener("pointerup", handlePointerLeave);
+    window.addEventListener("resize", onResize);
+
+    const loaderPromise = Promise.all([
+      loader.loadAsync(imageSrc),
+      loader.loadAsync(depthSrc)
+    ]);
+
+    loaderPromise
+      .then(([colorTexture, depthTexture]) => {
+        if (disposed) {
+          colorTexture.dispose();
+          depthTexture.dispose();
+          return;
+        }
+        colorTexture.colorSpace = THREE.SRGBColorSpace;
+        colorTexture.anisotropy = renderer!.capabilities.getMaxAnisotropy();
+        depthTexture.minFilter = THREE.LinearFilter;
+        depthTexture.magFilter = THREE.LinearFilter;
+        uniforms.u_tex.value = colorTexture;
+        uniforms.u_depth.value = depthTexture;
+
+        material = new THREE.ShaderMaterial({
+          vertexShader,
+          fragmentShader,
+          uniforms,
+          depthTest: false,
+          depthWrite: false
+        });
+        mesh = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material);
+        scene.add(mesh);
+        resize();
+        scheduleRender();
+      })
+      .catch(() => {
+        setHasDepth(false);
+      });
+
+    return () => {
+      disposed = true;
+      uniformsRef.current = null;
+      renderRef.current = null;
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      window.removeEventListener("resize", onResize);
+      container.removeEventListener("pointermove", handlePointerMove);
+      container.removeEventListener("pointerleave", handlePointerLeave);
+      container.removeEventListener("pointerup", handlePointerLeave);
+      if (gestureHandler) {
+        container.removeEventListener("click", gestureHandler);
+        container.removeEventListener("touchstart", gestureHandler);
+      }
+      if (orientationActive) {
+        window.removeEventListener("deviceorientation", orientationHandler, true);
+      }
+      if (mesh) {
+        scene.remove(mesh);
+        mesh.geometry.dispose();
+        if (Array.isArray(mesh.material)) {
+          mesh.material.forEach((m) => m.dispose());
+        } else {
+          mesh.material.dispose();
+        }
+      }
+      if (material) {
+        material.dispose();
+      }
+      if (renderer) {
+        renderer.dispose();
+      }
+      const tex = uniforms.u_tex.value;
+      const depthTex = uniforms.u_depth.value;
+      tex?.dispose();
+      depthTex?.dispose();
+    };
+  }, [shouldUseWebGL, imageSrc, depthSrc]);
+
+  useEffect(() => {
+    if (!renderRef.current || !uniformsRef.current) return;
+    uniformsRef.current.u_strength.value = strength;
+    renderRef.current();
+  }, [strength]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const fallbackImage = fallbackImageRef.current;
+    if (!container || !fallbackImage) return;
+    if (shouldUseWebGL || prefersReduced) {
+      fallbackImage.style.transform = "translate3d(0px, 0px, 0) scale(1.05)";
+      return;
+    }
+
+    let frameId: number | null = null;
+    const target = { x: 0, y: 0 };
+    const current = { x: 0, y: 0 };
+    const maxOffset = 20;
+
+    const animate = () => {
+      frameId = null;
+      current.x += (target.x - current.x) * 0.15;
+      current.y += (target.y - current.y) * 0.15;
+      fallbackImage.style.transform = `translate3d(${current.x}px, ${current.y}px, 0) scale(1.05)`;
+      if (Math.abs(current.x - target.x) > 0.1 || Math.abs(current.y - target.y) > 0.1) {
+        frameId = requestAnimationFrame(animate);
+      }
+    };
+
+    const schedule = () => {
+      if (frameId === null) {
+        frameId = requestAnimationFrame(animate);
+      }
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const rect = container.getBoundingClientRect();
+      const x = (event.clientX - rect.left) / rect.width;
+      const y = (event.clientY - rect.top) / rect.height;
+      target.x = (x * 2 - 1) * maxOffset;
+      target.y = -(y * 2 - 1) * maxOffset;
+      schedule();
+    };
+
+    const reset = () => {
+      target.x = 0;
+      target.y = 0;
+      schedule();
+    };
+
+    const orientationHandler = (event: DeviceOrientationEvent) => {
+      const beta = event.beta ?? 0;
+      const gamma = event.gamma ?? 0;
+      target.x = THREE.MathUtils.clamp(gamma / 45, -1, 1) * maxOffset;
+      target.y = -THREE.MathUtils.clamp(beta / 45, -1, 1) * maxOffset;
+      schedule();
+    };
+
+    let orientationActive = false;
+    const enableOrientation = () => {
+      if (orientationActive) return;
+      window.addEventListener("deviceorientation", orientationHandler, true);
+      orientationActive = true;
+    };
+
+    let gestureHandler: (() => void) | null = null;
+    if (typeof DeviceOrientationEvent !== "undefined") {
+      const anyOrientationEvent = DeviceOrientationEvent as unknown as {
+        requestPermission?: () => Promise<string>;
+      };
+      if (typeof anyOrientationEvent.requestPermission === "function") {
+        gestureHandler = () => {
+          anyOrientationEvent
+            .requestPermission!()
+            .then((state) => {
+              if (state === "granted") {
+                enableOrientation();
+              }
+            })
+            .catch(() => {
+              /* ignored */
+            });
+        };
+        container.addEventListener("click", gestureHandler, { once: true });
+        container.addEventListener("touchstart", gestureHandler, {
+          once: true
+        });
+      } else {
+        enableOrientation();
+      }
+    }
+
+    container.addEventListener("pointermove", handlePointerMove);
+    container.addEventListener("pointerleave", reset);
+    container.addEventListener("pointerup", reset);
+
+    return () => {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      container.removeEventListener("pointermove", handlePointerMove);
+      container.removeEventListener("pointerleave", reset);
+      container.removeEventListener("pointerup", reset);
+      if (gestureHandler) {
+        container.removeEventListener("click", gestureHandler);
+        container.removeEventListener("touchstart", gestureHandler);
+      }
+      if (orientationActive) {
+        window.removeEventListener("deviceorientation", orientationHandler, true);
+      }
+    };
+  }, [shouldUseWebGL, prefersReduced]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={["hero-depth", className].filter(Boolean).join(" ")}
+      style={{ "--fade-start": `${fadeValue * 100}%` } as CSSProperties}
+    >
+      {shouldUseWebGL ? (
+        <canvas ref={canvasRef} />
+      ) : (
+        <img
+          ref={fallbackImageRef}
+          src={imageSrc}
+          alt="Paisaje de montañas"
+          draggable={false}
+          style={{ transform: "scale(1.05)" }}
+        />
+      )}
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "aisa-group-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "three": "^0.161.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.66",
+    "typescript": "5.4.5"
+  }
+}

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+
+def log(message: str) -> None:
+  print(message, flush=True)
+
+
+def ensure_depth_map(image_path: Path, output_path: Path) -> None:
+  if not image_path.exists():
+    raise FileNotFoundError(f"No se encontró la imagen base: {image_path}")
+
+  device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+  log(f"Usando dispositivo: {device}")
+
+  model_type = "DPT_Small"
+  log("Cargando modelo MiDaS...")
+  model = torch.hub.load("intel-isl/MiDaS", model_type)
+  model.to(device)
+  model.eval()
+
+  transforms = torch.hub.load("intel-isl/MiDaS", "transforms")
+  transform = transforms.small_transform
+
+  image = Image.open(image_path).convert("RGB")
+  input_batch = transform(image).to(device)
+
+  with torch.no_grad():
+    prediction = model(input_batch)
+    prediction = torch.nn.functional.interpolate(
+      prediction.unsqueeze(1) if prediction.ndim == 2 else prediction,
+      size=image.size[::-1],
+      mode="bicubic",
+      align_corners=False
+    ).squeeze()
+
+  depth = prediction.cpu().numpy()
+  depth_min, depth_max = depth.min(), depth.max()
+  if depth_max - depth_min < 1e-6:
+    normalized = np.zeros_like(depth, dtype=np.uint8)
+  else:
+    normalized = (depth - depth_min) / (depth_max - depth_min)
+    normalized = (normalized * 255.0).clip(0, 255).astype(np.uint8)
+
+  output_path.parent.mkdir(parents=True, exist_ok=True)
+  Image.fromarray(normalized).save(output_path)
+  log(f"Mapa de profundidad guardado en {output_path}")
+
+
+if __name__ == "__main__":
+  project_root = Path(__file__).resolve().parents[1]
+  image_path = project_root / "public" / "hero" / "montanas.jpg"
+  output_path = project_root / "public" / "hero" / "montanas-depth.png"
+
+  try:
+    ensure_depth_map(image_path, output_path)
+  except Exception as error:  # pragma: no cover
+    log(f"Error generando el mapa de profundidad: {error}")
+    sys.exit(1)

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,77 @@
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: #000;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
+    sans-serif;
+  color: #fff;
+}
+
+body {
+  background: #000;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.global-background {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background: #000;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 6rem;
+}
+
+section {
+  padding: clamp(2rem, 6vw, 6rem) clamp(1.5rem, 6vw, 8rem);
+  max-width: 60ch;
+}
+
+section h1,
+section h2 {
+  margin-bottom: 1rem;
+}
+
+.hero-depth {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  --fade-start: 70%;
+  mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 1) var(--fade-start),
+    rgba(0, 0, 0, 0) 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 1) var(--fade-start),
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.hero-depth canvas,
+.hero-depth img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.hero-depth img {
+  transition: transform 0.4s ease;
+  will-change: transform;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "react"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 app router project with global styling for a black theme
- implement a HeroDepth component with Three.js parallax, reduced-motion and depth-map fallbacks
- add automation to generate and commit a MiDaS-based depth map when the hero image changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6de62ef74832db98918e724b9cf77