### PR TITLE
Fix Netlify plugin declaration syntax

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
   command = "npm run build"
   publish = ".next"
 
-[plugins]
+[[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- update Netlify configuration to declare the Next.js plugin using array syntax

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f3e0c9d0832da5c801b03c1e9ab5